### PR TITLE
Created a way to show proper stack trace for chai-as-promised using bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register"
+    "test": "BLUEBIRD_DEBUG=1 ./node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bluebird": "^2.9.34",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "coffee-script": "^1.9.3",
-    "lie": "^2.9.1",
     "mocha": "^2.2.5"
   }
 }

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,8 +1,8 @@
+global.Promise = require 'bluebird'
 chai = require('chai');
 chai.should();
 chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised)
-Promise = require 'lie'
 
 promiser = ->
   new Promise (resolve, reject)->


### PR DESCRIPTION
Hi there!

I ran into this same problem and came across your repo and SO question in trying to find a solution. I'm not on SO so I'm giving you my solution here.

Basically if you use Bluebird and enable long stack traces (through that BLUEBIRD_DEBUG environment variable), you get proper stack traces for chai-as-promised assertions.
